### PR TITLE
fix: update test command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "dev": "./node_modules/.bin/serverless offline start -s dev --httpPort 1337 --lambdaPort 4000 --allowCache",
-    "test": "./node_modules/.bin/mocha -r ts-node/register ./shared/**/*.spec.ts ./functions/**/*.spec.ts --exit",
+    "test": "./node_modules/.bin/mocha -r ts-node/register \"./shared/**/*.spec.ts\" \"./functions/**/*.spec.ts\" --exit",
     "format": "./node_modules/.bin/prettier --write ./shared/**/*.ts functions/**/*.ts",
     "lint": "./node_modules/.bin/eslint -c eslint.json --ext .ts functions/",
     "lint-fix": "./node_modules/.bin/eslint -c eslint.json --ext .ts --fix functions/",


### PR DESCRIPTION
Command without double quotes will be processed by process.argv so  when we provide tests in different level of directory argv can change our pattern and we will have a problem with running all tests