### PR TITLE
bugfix: remove stage option from serverless config

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -16,7 +16,7 @@ definitions:
           - node
         script:
           - npm install
-          - ./node_modules/.bin/serverless config credentials --stage ${STAGE} --provider aws --key ${AWS_LAMBDA_KEY} --secret ${AWS_LAMBDA_SECRET}
+          - ./node_modules/.bin/serverless config credentials --provider aws --key ${AWS_LAMBDA_KEY} --secret ${AWS_LAMBDA_SECRET}
           - ./node_modules/.bin/serverless deploy --stage ${STAGE}
 
 pipelines:


### PR DESCRIPTION
<img width="549" alt="image" src="https://user-images.githubusercontent.com/25750964/185969866-8cd214f4-1560-4de3-a0c1-1dd84f1912a3.png">
"stage" option does not exist in: "serverless config credentials"