### PR TITLE
chore: replace validator package 'joi' to 'yup' to get better type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Here you can check example tests: [handler.spec.ts](functions/example-lambda/tes
 
 ### What do we use for validating schemas?
 
-We use [joi](https://joi.dev/) for schema validation.
+We use [yup](https://github.com/jquense/yup) for schema validation.
 
 ##
 

--- a/functions/example-lambda/config/index.ts
+++ b/functions/example-lambda/config/index.ts
@@ -1,22 +1,14 @@
-import Joi from "joi";
+import { object, string } from "yup";
 import { pipeline } from "ts-pipe-compose";
 
-const loadEnvs = (env: any) => ({
+const loadEnvs = (env: NodeJS.ProcessEnv) => ({
   appName: env.APP_NAME,
 });
 
-const validateConfig = (config: any) => {
-  const schema = Joi.object().keys({
-    appName: Joi.string().required(),
-  });
+const schema = object({
+  appName: string().required(),
+});
 
-  const { error, value } = schema.validate(config);
-
-  if (error) {
-    throw error;
-  }
-
-  return value;
-};
+const validateConfig = (config: Record<string, unknown>) => schema.validateSync(config);
 
 export const createConfig = pipeline(loadEnvs, validateConfig);

--- a/functions/example-lambda/event.schema.ts
+++ b/functions/example-lambda/event.schema.ts
@@ -1,8 +1,8 @@
-import joi from "joi";
-import { JoiValidatorSchema } from "../../shared/middleware/joi-validator";
+import { object, string } from "yup";
+import { YupValidatorSchema } from "../../shared/middleware/yup-validator";
 
-export const schema: JoiValidatorSchema = {
-  query: joi.object().keys({
-    exampleParam: joi.string().required(),
+export const schema: YupValidatorSchema = {
+  query: object({
+    exampleParam: string().required(),
   }),
 };

--- a/functions/example-lambda/handler.ts
+++ b/functions/example-lambda/handler.ts
@@ -8,7 +8,7 @@ import { ConnectionManager } from "../../shared/utils/connection-manager";
 import { ExampleModel } from "../../shared/models/example.model";
 import { v4 } from "uuid";
 import { createConfig } from "./config";
-import { joiValidator } from "../../shared/middleware/joi-validator";
+import { yupValidator } from "../../shared/middleware/yup-validator";
 import { schema } from "./event.schema";
 import { inputOutputLoggerConfigured } from "../../shared/middleware/input-output-logger-configured";
 import { customHttpErrorHandler } from "../../shared/middleware/custom-http-error-handler";
@@ -42,5 +42,5 @@ export const handle = middy(async (event: APIGatewayEvent, _context: Context): P
   .use(httpEventNormalizer())
   .use(httpHeaderNormalizer())
   .use(queryParser())
-  .use(joiValidator(schema))
+  .use(yupValidator(schema))
   .use(customHttpErrorHandler());

--- a/package-lock.json
+++ b/package-lock.json
@@ -487,6 +487,14 @@
         "@babel/plugin-transform-typescript": "^7.16.7"
       }
     },
+    "@babel/runtime": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.4.tgz",
+      "integrity": "sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
@@ -1200,7 +1208,8 @@
     "@hapi/hoek": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
-      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+      "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
+      "dev": true
     },
     "@hapi/iron": {
       "version": "6.0.0",
@@ -1354,6 +1363,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -1750,24 +1760,6 @@
         }
       }
     },
-    "@sideway/address": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
-      "integrity": "sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@sideway/formula": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
-    },
-    "@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
-    },
     "@sindresorhus/is": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.4.0.tgz",
@@ -1943,8 +1935,7 @@
     "@types/lodash": {
       "version": "4.14.178",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
-      "dev": true
+      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw=="
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -6986,18 +6977,6 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
-    "joi": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
-      "integrity": "sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -7378,8 +7357,12 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -8017,6 +8000,11 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "nanoid": {
       "version": "3.2.0",
@@ -9340,6 +9328,11 @@
       "integrity": "sha1-L29ffA9tCBCelnZZx5uIqe1ek7Q=",
       "dev": true
     },
+    "property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -9548,6 +9541,11 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
+      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
     },
     "regexp-tree": {
       "version": "0.1.24",
@@ -11505,6 +11503,11 @@
         }
       }
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -12588,6 +12591,20 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     },
     "zen-observable": {
       "version": "0.8.15",

--- a/package.json
+++ b/package.json
@@ -75,12 +75,12 @@
     "aws-sdk": "^2.1081.0",
     "dotenv": "^16.0.0",
     "http-status-codes": "^2.2.0",
-    "joi": "^17.6.0",
     "pg": "^8.7.3",
     "ts-loader": "^9.2.6",
     "ts-pipe-compose": "^0.2.1",
     "typeorm": "^0.2.44",
     "uuid": "^8.3.2",
-    "winston": "^3.6.0"
+    "winston": "^3.6.0",
+    "yup": "^0.32.11"
   }
 }

--- a/plop-templates/function/config/index.ts
+++ b/plop-templates/function/config/index.ts
@@ -1,22 +1,14 @@
-import Joi from "joi";
+import { object, string} from "yup";
 import { pipeline } from "ts-pipe-compose";
 
-const loadEnvs = (env: any) => ({
+const loadEnvs = (env: NodeJS.ProcessEnv) => ({
   appName: env.APP_NAME,
 });
 
-const validateConfig = (config: any) => {
-  const schema = Joi.object().keys({
-    appName: Joi.string().required(),
-  });
+const schema = object({
+  appName: string().required(),
+})
 
-  const { error, value } = schema.validate(config);
-
-  if (error) {
-    throw error;
-  }
-
-  return value;
-};
+const validateConfig = (config: Record<string, unknown>) => schema.validateSync(config);
 
 export const createConfig = pipeline(loadEnvs, validateConfig);

--- a/plop-templates/function/event.schema.ts
+++ b/plop-templates/function/event.schema.ts
@@ -1,8 +1,8 @@
-import joi from "joi";
-import { JoiValidatorSchema } from "../../shared/middleware/joi-validator";
+import { object, string } from "yup";
+import { YupValidatorSchema } from "../../shared/middleware/yup-validator";
 
-export const schema: JoiValidatorSchema = {
-  query: joi.object().keys({
-    exampleParam: joi.string().required(),
+export const schema: YupValidatorSchema = {
+  query: object({
+    exampleParam: string().required(),
   }),
 };

--- a/shared/aws.ts
+++ b/shared/aws.ts
@@ -1,5 +1,5 @@
 import { commonHeaders } from "./headers";
-import { ValidationError } from "joi";
+import { ValidationError } from "yup";
 import { AppError } from "./errors/app.error";
 import { HttpError } from "./errors/http.error";
 
@@ -15,7 +15,7 @@ export const awsLambdaResponse = (statusCode: number, body?: any) => {
 
 export const createErrorResponse = (error) => {
   if (error instanceof ValidationError) {
-    return awsLambdaResponse(400, error.details);
+    return awsLambdaResponse(400, { path: error.path, message: error.message });
   }
 
   if (error instanceof HttpError) {

--- a/shared/schema-validator.ts
+++ b/shared/schema-validator.ts
@@ -1,7 +1,7 @@
-import Joi from "joi";
+import { AnySchema } from "yup";
 
-export const createSchemaValidator = (schema: Joi.ObjectSchema) => {
-  return (input: any) => {
-    return Joi.attempt(input, schema);
+export const createSchemaValidator = <T extends AnySchema>(schema: T) => {
+  return (input: unknown) => {
+    return schema.validateSync(input);
   };
 };


### PR DESCRIPTION
It seems worth using a package that will give us a better type-safe. Let me know what you think about it

<img width="756" alt="image" src="https://user-images.githubusercontent.com/26671751/196554568-97b33375-a04b-456a-847b-20a71d16a1cf.png">

After that, It would be nice if yupValidator, could give us the inferred type to handlers based on the schema