### PR TITLE
chore: add script for debugging lambdas in IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ docker-compose up
 
 ##
 
+### Debugging locally
+
+Serverless uses workers to run lambdas locally. To debug them in your IDE you need to add `--useInProcess` flag, or run the following command:
+
+```
+npm run dev-with-debug
+```
+
+##
+
 ### Run workflow locally
 
 - npm run start-workflow --workflow=NAME_OF_THE_WORKFLOW

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "dev": "./node_modules/.bin/serverless offline start -s dev --httpPort 1337 --lambdaPort 4000",
+    "dev-with-debug": "./node_modules/.bin/serverless offline start -s dev --httpPort 1337 --lambdaPort 4000 --reloadHandler --useInProcess",
     "test": "./node_modules/.bin/mocha -r ts-node/register ./shared/**/*.spec.ts ./functions/**/*.spec.ts --exit",
     "format": "./node_modules/.bin/prettier --write .",
     "lint": "./node_modules/.bin/eslint -c eslint.json --ext .ts functions/ --ext .ts workflows/ --ext .ts shared/",


### PR DESCRIPTION
## Problem

Can't debug in IDE

## Solution

Added `--useInProcess` flag to serverless that forces node to run handlers in the same process as 'serverless-offline'.