### PR TITLE
fix: Update plop templates to meet kebabcase filename conventions

### DIFF
--- a/plop-templates/function/event.schema.ts
+++ b/plop-templates/function/event.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const exampleLambdaSchema = z.object({
+export const {{camelCase name}}LambdaSchema = z.object({
   queryStringParameters: z.object({
     exampleParam: z
       .string({
@@ -10,4 +10,4 @@ export const exampleLambdaSchema = z.object({
   }),
 });
 
-export type ExampleLambdaPayload = z.infer<typeof exampleLambdaSchema>;
+export type {{pascalCase name}}LambdaPayload = z.infer<typeof {{camelCase name}}LambdaSchema>;

--- a/plop-templates/function/function.yml
+++ b/plop-templates/function/function.yml
@@ -1,5 +1,5 @@
-{{name}}:
-  handler: functions/{{name}}/handler.handle
+{{ kebabCase name }}:
+  handler: functions/{{kebabCase name}}/handler.handle
   vpc: ${self:custom.vpc}
   environment:
     POSTGRES_URL: ${env:POSTGRES_URL}

--- a/plop-templates/function/handler.ts
+++ b/plop-templates/function/handler.ts
@@ -7,7 +7,7 @@ import { winstonLogger } from "../../shared/logger";
 import { dataSource } from "../../shared/config/db";
 import { createConfig } from "./config";
 import { inputOutputLoggerConfigured } from "../../shared/middleware/input-output-logger-configured";
-import {ExampleLambdaPayload} from "./event.schema";
+import { {{pascalCase name}}LambdaPayload } from "./event.schema";
 import {zodValidator} from "../../shared/middleware/zod-validator";
 import {exampleLambdaSchema} from "../../functions/example-lambda/event.schema";
 import {queryParser} from "../../shared/middleware/query-parser";
@@ -16,7 +16,7 @@ import {httpErrorHandlerConfigured} from "../../shared/middleware/http-error-han
 const connectToDb = dataSource.initialize();
 const config = createConfig(process.env);
 
-const lambdaHandler = async (event: ExampleLambdaPayload) => {
+const lambdaHandler = async (event: {{pascalCase name}}LambdaPayload) => {
   winstonLogger.info("Pre connection");
   winstonLogger.info(`Config: ${JSON.stringify(config)}`);
   await connectToDb;

--- a/plop-templates/workflow/step/function.yml
+++ b/plop-templates/workflow/step/function.yml
@@ -1,2 +1,2 @@
-{{name}}-lambda:
-  handler: workflows/{{workflow}}/{{name}}/handler.handle
+{{ kebabCase name }}-lambda:
+  handler: workflows/{{workflow}}/{{kebabCase name}}/handler.handle

--- a/plop-templates/workflow/workflow.asl.yml
+++ b/plop-templates/workflow/workflow.asl.yml
@@ -1,4 +1,4 @@
-Comment: "{{properCase name}} Workflow"
+Comment: "{{sentenceCase name}} Workflow"
 StartAt: exampleStep
 States:
   # PLOP_ADD_WORKFLOW_STEP

--- a/plop-templates/workflow/workflow.yml
+++ b/plop-templates/workflow/workflow.yml
@@ -1,2 +1,2 @@
-name: {{properCase name}}${self:service}${opt:stage, 'dev'}
+name: {{pascalCase name}}Workflow${self:service}${opt:stage, 'dev'}
 definition: ${file(./workflows/{{kebabCase name}}/workflow.asl.yml)}

--- a/plopfile.js
+++ b/plopfile.js
@@ -24,10 +24,10 @@ const createModel = {
 };
 
 const workflowResourceTemplate = `
-    {{properCase name}}StateMachine:
+    {{pascalCase name}}WorkflowStateMachine:
       Description: {{sentenceCase name}} state machine Arn
       Value:
-        Ref: {{properCase name}}\${self:service}\${opt:stage, 'dev'}
+        Ref: {{pascalCase name}}Workflow\${self:service}\${opt:stage, 'dev'}
     $1
 `;
 
@@ -111,19 +111,19 @@ module.exports = function (plop) {
     actions: [
       {
         type: "add",
-        path: "workflows/{{name}}/workflow.yml",
+        path: "workflows/{{kebabCase name}}/workflow.yml",
         templateFile: "plop-templates/workflow/workflow.yml",
       },
       {
         type: "add",
-        path: "workflows/{{name}}/workflow.asl.yml",
+        path: "workflows/{{kebabCase name}}/workflow.asl.yml",
         templateFile: "plop-templates/workflow/workflow.asl.yml",
       },
       {
         type: "modify",
         path: "serverless.yml",
         pattern: / +(\# PLOP_ADD_WORKFLOW_STATE_MACHINE)/,
-        template: "    {{properCase name}}: ${file(workflows/{{name}}/workflow.yml)}\n  $1",
+        template: "    {{pascalCase name}}Workflow: ${file(workflows/{{kebabCase name}}/workflow.yml)}\n  $1",
       },
       {
         type: "modify",

--- a/plopfile.js
+++ b/plopfile.js
@@ -33,7 +33,7 @@ const workflowResourceTemplate = `
 
 const workFlowStepTemplate = `  {{camelCase name}}Step:
     Type: Task
-    Resource: !GetAtt {{name}}-lambda.Arn
+    Resource: !GetAtt {{kebabCase name}}-lambda.Arn
     TimeoutSeconds: 28
     End: true
   $1
@@ -146,19 +146,19 @@ module.exports = function (plop) {
     actions: [
       {
         type: "add",
-        path: "workflows/{{workflow}}/{{name}}/function.yml",
+        path: "workflows/{{workflow}}/{{kebabCase name}}/function.yml",
         templateFile: "plop-templates/workflow/step/function.yml",
       },
       {
         type: "add",
-        path: "workflows/{{workflow}}/{{name}}/handler.ts",
+        path: "workflows/{{workflow}}/{{kebabCase name}}/handler.ts",
         templateFile: "plop-templates/workflow/step/handler.ts",
       },
       {
         type: "modify",
         path: "serverless.yml",
         pattern: / +(\# PLOP_ADD_LAMBDA)/,
-        template: "  - ${file(workflows/{{workflow}}/{{name}}/function.yml)}\n  $1",
+        template: "  - ${file(workflows/{{workflow}}/{{kebabCase name}}/function.yml)}\n  $1",
       },
       {
         type: "modify",
@@ -171,7 +171,7 @@ module.exports = function (plop) {
         path: "serverless.yml",
         pattern: / +(\# PLOP_ADD_WORKFLOW_STEP_LOCAL_STEP)/,
         template:
-          "      {{camelCase name}}Step: arn:aws:lambda:us-east-1:101010101010:function:${env:APP_NAME, 'tshExampleApp'}-${opt:stage, 'dev'}-{{name}}-lambda\n      $1",
+          "      {{camelCase name}}Step: arn:aws:lambda:us-east-1:101010101010:function:${env:APP_NAME, 'tshExampleApp'}-${opt:stage, 'dev'}-{{kebabCase name}}-lambda\n      $1",
       },
     ],
   });

--- a/plopfile.js
+++ b/plopfile.js
@@ -73,29 +73,29 @@ module.exports = function (plop) {
     actions: [
       {
         type: "add",
-        path: "functions/{{name}}/handler.ts",
+        path: "functions/{{kebabCase name}}/handler.ts",
         templateFile: "plop-templates/function/handler.ts",
       },
       {
         type: "add",
-        path: "functions/{{name}}/event.schema.ts",
+        path: "functions/{{kebabCase name}}/event.schema.ts",
         templateFile: "plop-templates/function/event.schema.ts",
       },
       {
         type: "add",
-        path: "functions/{{name}}/config/index.ts",
+        path: "functions/{{kebabCase name}}/config/index.ts",
         templateFile: "plop-templates/function/config/index.ts",
       },
       {
         type: "add",
-        path: "functions/{{name}}/function.yml",
+        path: "functions/{{kebabCase name}}/function.yml",
         templateFile: "plop-templates/function/function.yml",
       },
       {
         type: "modify",
         path: "serverless.yml",
         pattern: / +(\# PLOP_ADD_LAMBDA)/,
-        template: "  - ${file(functions/{{name}}/function.yml)}\n  $1",
+        template: "  - ${file(functions/{{kebabCase name}}/function.yml)}\n  $1",
       },
     ],
   });


### PR DESCRIPTION
Plop templates are not unified, some of them using different naming conventions. 

This changes make that all of files will be generated using kebab case convention, and the workflow/types names will use pascal case convention.