### PR TITLE
feat: cors middleware

### DIFF
--- a/functions/example-lambda/handler.ts
+++ b/functions/example-lambda/handler.ts
@@ -13,6 +13,7 @@ import { ExampleLambdaPayload, exampleLambdaSchema } from "./event.schema";
 import { inputOutputLoggerConfigured } from "../../shared/middleware/input-output-logger-configured";
 import { queryParser } from "../../shared/middleware/query-parser";
 import { zodValidator } from "../../shared/middleware/zod-validator";
+import { httpCorsConfigured } from "../../shared/middleware/http-cors-configured";
 import { httpErrorHandlerConfigured } from "../../shared/middleware/http-error-handler-configured";
 
 const connectToDb = dataSource.initialize();
@@ -46,6 +47,7 @@ export const handle = middy()
   .use(inputOutputLoggerConfigured())
   .use(httpEventNormalizer())
   .use(httpHeaderNormalizer())
+  .use(httpCorsConfigured)
   .use(queryParser())
   .use(zodValidator(exampleLambdaSchema))
   .use(httpErrorHandlerConfigured)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@middy/core": "^4.2.7",
+        "@middy/http-cors": "^4.2.7",
         "@middy/http-error-handler": "^4.2.7",
         "@middy/http-event-normalizer": "^4.2.7",
         "@middy/http-header-normalizer": "^4.2.7",
@@ -2579,6 +2580,21 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.2.7.tgz",
       "integrity": "sha512-VXwtTEp2rqJedH12y6ye1nnHtXgvaBzgbF0cb5Vr3t+hkRV4z/D+5Iq0SG7N2425el2yQVvIhrdUNX+9/hZ4tw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/willfarrell"
+      }
+    },
+    "node_modules/@middy/http-cors": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-4.2.7.tgz",
+      "integrity": "sha512-G57c98+mA5oqg0ZuQ21T2qmt27yZFT/vZM3uJSSEl7nzxThVG1dt5xia6yqSYkISusSmr7uTNzw2nOXHgr0HUA==",
+      "dependencies": {
+        "@middy/util": "4.2.7"
+      },
       "engines": {
         "node": ">=16"
       },

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "@middy/core": "^4.2.7",
+    "@middy/http-cors": "^4.2.7",
     "@middy/http-error-handler": "^4.2.7",
     "@middy/http-event-normalizer": "^4.2.7",
     "@middy/http-header-normalizer": "^4.2.7",

--- a/plop-templates/function/handler.ts
+++ b/plop-templates/function/handler.ts
@@ -2,6 +2,7 @@ import middy from "@middy/core";
 import httpEventNormalizer from "@middy/http-event-normalizer";
 import httpHeaderNormalizer from "@middy/http-header-normalizer";
 import jsonBodyParser from "@middy/http-json-body-parser";
+import { StatusCodes } from "http-status-codes";
 import { awsLambdaResponse } from "../../shared/aws";
 import { winstonLogger } from "../../shared/logger";
 import { dataSource } from "../../shared/config/db";
@@ -11,8 +12,8 @@ import { {{pascalCase name}}LambdaPayload } from "./event.schema";
 import { zodValidator } from "../../shared/middleware/zod-validator";
 import { exampleLambdaSchema } from "../example-lambda/event.schema";
 import { queryParser } from "../../shared/middleware/query-parser";
+import { httpCorsConfigured } from "../../shared/middleware/http-cors-configured";
 import { httpErrorHandlerConfigured } from "../../shared/middleware/http-error-handler-configured";
-import { StatusCodes } from "http-status-codes";
 
 const connectToDb = dataSource.initialize();
 const config = createConfig(process.env);
@@ -34,6 +35,7 @@ export const handle = middy()
   .use(inputOutputLoggerConfigured())
   .use(httpEventNormalizer())
   .use(httpHeaderNormalizer())
+  .use(httpCorsConfigured)
   .use(queryParser())
   .use(zodValidator(exampleLambdaSchema))
   .use(httpErrorHandlerConfigured)

--- a/shared/aws.ts
+++ b/shared/aws.ts
@@ -1,14 +1,10 @@
 import { StatusCodes } from "http-status-codes";
-import { commonHeaders } from "./headers";
 import { AppError } from "./errors/app.error";
 import { HttpError } from "./errors/http.error";
 
 export const awsLambdaResponse = (statusCode: number, body?: any) => ({
   statusCode,
   body: body ? JSON.stringify(body) : body,
-  headers: {
-    ...commonHeaders,
-  },
 });
 
 export const createErrorResponse = (error: any) => {

--- a/shared/headers.ts
+++ b/shared/headers.ts
@@ -1,5 +1,0 @@
-export const commonHeaders = {
-  "Access-Control-Allow-Origin": "*", // Required for CORS support to work
-  "Access-Control-Allow-Credentials": true, // Required for cookies, authorization headers with HTTPS
-  "Access-Control-Allow-Methods": "POST,GET,OPTIONS,PATCH",
-};

--- a/shared/middleware/http-cors-configured.ts
+++ b/shared/middleware/http-cors-configured.ts
@@ -1,0 +1,4 @@
+import cors from "@middy/http-cors";
+import { httpCorsConfig } from "./utils/http-cors.config";
+
+export const httpCorsConfigured = cors(httpCorsConfig);

--- a/shared/middleware/utils/http-cors.config.ts
+++ b/shared/middleware/utils/http-cors.config.ts
@@ -1,0 +1,4 @@
+export const httpCorsConfig = {
+  credentials: true,
+  methods: "POST,PUT,GET,OPTIONS,PATCH",
+};

--- a/shared/middleware/utils/input-output-logger.config.ts
+++ b/shared/middleware/utils/input-output-logger.config.ts
@@ -1,7 +1,7 @@
 import { winstonLogger } from "../../logger";
 
 export const loggerOptions = {
-  logger: (request) => {
+  logger: (request: any) => {
     const log = request.event ?? request.response;
     winstonLogger.info(typeof log === "string" ? log : JSON.stringify(log));
   },


### PR DESCRIPTION
In previous approach cors headers were not added for 400 responses (errors thrown from zod-validator) 

@middy/http-cors sets headers in `after` and `onError` phases.