### PR TITLE
chore: remove sls plugin log retention

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "prettier": "^2.8.4",
         "serverless": "^3.34.0",
         "serverless-offline": "^12.0.4",
-        "serverless-plugin-log-retention": "^2.0.0",
         "serverless-plugin-typescript": "^2.1.5",
         "serverless-step-functions": "^3.14.0",
         "serverless-step-functions-local": "^0.5.0",
@@ -11107,12 +11106,6 @@
         "type": "^2.7.2"
       }
     },
-    "node_modules/nco": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nco/-/nco-1.0.1.tgz",
-      "integrity": "sha512-tjlHSkSvVzRGeBXIOimMTA2J3ZUP9LLUvqv+JeBLGAseZP1syF/LgetKNJ8zMiXosuKJHx7/KSIv8UDyKXoeKQ==",
-      "dev": true
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -13834,25 +13827,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/serverless-plugin-log-retention": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/serverless-plugin-log-retention/-/serverless-plugin-log-retention-2.0.0.tgz",
-      "integrity": "sha512-TXKMfLdVxhamyaDbqr+gwjIeiqSnDw3z+bZQy0W2ctRpcedUY8hg58wwMZqAFyMS3QekHT9srCe4Qv7lfPwkGw==",
-      "dev": true,
-      "dependencies": {
-        "nco": "1.0.1",
-        "semver": "5.4.1"
-      }
-    },
-    "node_modules/serverless-plugin-log-retention/node_modules/semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/serverless-plugin-typescript": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "prettier": "^2.8.4",
     "serverless": "^3.34.0",
     "serverless-offline": "^12.0.4",
-    "serverless-plugin-log-retention": "^2.0.0",
     "serverless-plugin-typescript": "^2.1.5",
     "serverless-step-functions": "^3.14.0",
     "serverless-step-functions-local": "^0.5.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,6 @@ plugins:
   - serverless-step-functions
   - serverless-webpack
   - serverless-offline
-  - serverless-plugin-log-retention
 
 package:
   individually: true
@@ -17,7 +16,6 @@ custom:
     subnetIds:
       - ${env:SUBNET_ID_1}
       - ${env:SUBNET_ID_2}
-  logRetentionInDays: 30
   webpack:
     webpackConfig: "webpack.config.js"
     packager: "npm"
@@ -37,6 +35,7 @@ provider:
   stage: ${opt:stage, 'dev'}
   memorySize: 256
   timeout: 30
+  logRetentionInDays: 30
   environment:
     APP_NAME: ${env:APP_NAME, 'tshExampleApp'}
     AWS_LAMBDAS_REGION: ${env:AWS_LAMBDAS_REGION, 'eu-west-1'}


### PR DESCRIPTION
As per https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml#general-function-settings
`logRetentionInDays` is supported for lambda log groups and api gw logs. No plugins needed 
