### PR TITLE
Feat/standard datagrid

### DIFF
--- a/functions/example-lambda/event.schema.ts
+++ b/functions/example-lambda/event.schema.ts
@@ -7,6 +7,10 @@ export const exampleLambdaSchema = z.object({
         required_error: "exampleParam is required",
       })
       .min(1, "exampleParam can't be empty"),
+    page: z.string().optional(),
+    limit: z.string().optional(),
+    sort: z.record(z.string()).optional(),
+    filter: z.record(z.string()).optional(),
   }),
 });
 

--- a/functions/example-lambda/function.yml
+++ b/functions/example-lambda/function.yml
@@ -5,5 +5,5 @@ example-lambda:
     POSTGRES_URL: ${env:POSTGRES_URL}
   events:
     - http:
-        path: /
+        path: /users
         method: GET

--- a/functions/example-lambda/handler.ts
+++ b/functions/example-lambda/handler.ts
@@ -29,7 +29,9 @@ const lambdaHandler = async (event: ExampleLambdaPayload) => {
 
   await connectToDb;
 
-  const { page, limit, sort, filter } = event.queryStringParameters;
+  const { page: pageString, limit: limitString, sort, filter } = event.queryStringParameters;
+  const page = Number(pageString);
+  const limit = Number(limitString);
   const findOptions = {} as any;
 
   if (limit && page) {

--- a/functions/example-lambda/handler.ts
+++ b/functions/example-lambda/handler.ts
@@ -6,7 +6,6 @@ import { awsLambdaResponse } from "../../shared/aws";
 import { winstonLogger } from "../../shared/logger";
 import { dataSource } from "../../shared/config/db";
 import { ExampleModel } from "../../shared/models/example.model";
-import { randomUUID } from "crypto";
 import { StatusCodes } from "http-status-codes";
 import { createConfig } from "./config";
 import { ExampleLambdaPayload, exampleLambdaSchema } from "./event.schema";
@@ -15,31 +14,40 @@ import { queryParser } from "../../shared/middleware/query-parser";
 import { zodValidator } from "../../shared/middleware/zod-validator";
 import { httpCorsConfigured } from "../../shared/middleware/http-cors-configured";
 import { httpErrorHandlerConfigured } from "../../shared/middleware/http-error-handler-configured";
+import {
+  calculateSkipFindOption,
+  isFilterAvailable,
+  makePaginationResult,
+} from "../../shared/pagination-utils/pagination-utils";
 
 const connectToDb = dataSource.initialize();
 const config = createConfig(process.env);
+const userRepository = dataSource.getRepository(ExampleModel);
 
 const lambdaHandler = async (event: ExampleLambdaPayload) => {
   winstonLogger.info(`Hello from ${config.appName}. Example param is: ${event.queryStringParameters.exampleParam}`);
 
   await connectToDb;
 
-  await dataSource.getRepository(ExampleModel).save(
-    ExampleModel.create({
-      id: randomUUID(),
-      email: "some@tmp.pl",
-      firstName: "Test",
-      lastName: "User",
-    }),
-  );
+  const { page, limit, sort, filter } = event.queryStringParameters;
+  const findOptions = {} as any;
 
-  return awsLambdaResponse(StatusCodes.OK, {
-    success: true,
-    data: {
-      users: await dataSource.getRepository(ExampleModel).find(),
-      exampleParam: event.queryStringParameters.exampleParam,
-    },
-  });
+  if (limit && page) {
+    findOptions.take = limit;
+    findOptions.skip = calculateSkipFindOption(page, limit);
+  }
+
+  if (sort && isFilterAvailable(sort, userRepository)) {
+    findOptions.order = sort;
+  }
+
+  if (filter && isFilterAvailable(filter, userRepository)) {
+    findOptions.where = filter;
+  }
+
+  const [data, total] = await userRepository.findAndCount(findOptions);
+
+  return awsLambdaResponse(StatusCodes.OK, makePaginationResult(data, total, limit, page));
 };
 
 export const handle = middy()

--- a/functions/example-lambda/tests/handler.spec.ts
+++ b/functions/example-lambda/tests/handler.spec.ts
@@ -5,11 +5,11 @@ describe("test endpoint", () => {
 
   describe("Test obligatory query parameter", () => {
     it("GET `dev/?exampleParam=test` returns 200", () => {
-      return server.get("dev/").query("exampleParam=test").expect(200);
+      return server.get("dev/users").query("exampleParam=test").expect(200);
     });
 
     it("GET `dev` returns bad request", () => {
-      return server.get("dev/").expect(400);
+      return server.get("dev/users").expect(400);
     });
 
     it("GET 'any' returns not found", () => {

--- a/migrations/1667584203150-migration.ts
+++ b/migrations/1667584203150-migration.ts
@@ -7,6 +7,7 @@ export class migration1667584203150 implements MigrationInterface {
     await queryRunner.query(
       `CREATE TABLE "example-model" ("id" character varying NOT NULL, "email" character varying NOT NULL, "firstName" character varying NOT NULL, "lastName" character varying NOT NULL, CONSTRAINT "PK_531218052145e12c28736ad2e86" PRIMARY KEY ("id"))`,
     );
+    await queryRunner.query(`INSERT INTO "example-model"(id, "firstName", "lastName", email) VALUES ('bc3a9e05-893d-4589-8190-3d31c2db75b4', 'John', 'Doe', 'john@doe.com'), ('90a0742d-ced4-4356-b91f-e7bad03f3eca', 'Mark', 'Smith', 'mark@smith.com')`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/shared/pagination-utils/pagination-utils.spec.ts
+++ b/shared/pagination-utils/pagination-utils.spec.ts
@@ -1,0 +1,58 @@
+import assert from "assert";
+import { makePaginationResult } from "./pagination-utils";
+
+describe("pagination-utils", () => {
+  const data = [
+    {
+      id: "155bed9b-54d9-4605-b2cb-c4b19618d28b",
+      firstName: "John",
+      lastName: "Doe",
+      email: "john@doe.com",
+    },
+    {
+      id: "85e8ec60-1cc6-471a-9894-06a03560731c",
+      firstName: "John2",
+      lastName: "Doe2",
+      email: "john2@doe.com",
+    },
+  ];
+
+  it("returns valid pagination", () => {
+    const result = makePaginationResult(data, 10, 4, 2);
+    assert.deepEqual(result, {
+      meta: {
+        page: 2,
+        limit: 4,
+        total: 10,
+        totalPages: 3,
+      },
+      data,
+    });
+  });
+
+  it("returns valid pagination if limit is 0", () => {
+    const result = makePaginationResult(data, 10, 0, 2);
+    assert.deepEqual(result, {
+      meta: {
+        page: 2,
+        limit: 0,
+        total: 10,
+        totalPages: null,
+      },
+      data,
+    });
+  });
+
+  it("returns first page if passed 0 page", () => {
+    const result = makePaginationResult(data, 10, 5, 2);
+    assert.deepEqual(result, {
+      meta: {
+        page: 2,
+        limit: 5,
+        total: 10,
+        totalPages: 2,
+      },
+      data,
+    });
+  });
+});

--- a/shared/pagination-utils/pagination-utils.ts
+++ b/shared/pagination-utils/pagination-utils.ts
@@ -11,8 +11,8 @@ export interface PaginationResult {
   data: any;
 }
 
-export function calculateSkipFindOption(page: string, limit: string) {
-  return (Number(page) - 1) * Number(limit);
+export function calculateSkipFindOption(page: number, limit: number) {
+  return (page - 1) * limit;
 }
 
 export function isFilterAvailable(filter: any, repository: Repository<any>): boolean {
@@ -24,18 +24,14 @@ export function isFilterAvailable(filter: any, repository: Repository<any>): boo
   throw new AppError("Invalid query string");
 }
 
-export function makePaginationResult(data: any, total: number, limit?: string, page?: string): PaginationResult {
+export function makePaginationResult(data: any, total: number, limit?: number, page?: number): PaginationResult {
   return {
     meta: {
-      page: Number(page) || 1,
-      limit: Number(limit),
+      page: page || 1,
+      limit,
       total,
-      totalPages: limit ? Math.ceil(total / Math.max(Number(limit), 1)) : null,
+      totalPages: limit ? Math.ceil(total / Math.max(limit, 1)) : null,
     },
     data,
   };
-}
-
-export function normalizePage(page: number) {
-  return Math.max(page - 1, 0);
 }

--- a/shared/pagination-utils/pagination-utils.ts
+++ b/shared/pagination-utils/pagination-utils.ts
@@ -1,0 +1,41 @@
+import { Repository } from "typeorm";
+import { AppError } from "../errors/app.error";
+
+export interface PaginationResult {
+  meta: {
+    page?: number;
+    limit?: number;
+    total: number;
+    totalPages: number | null;
+  };
+  data: any;
+}
+
+export function calculateSkipFindOption(page: string, limit: string) {
+  return (Number(page) - 1) * Number(limit);
+}
+
+export function isFilterAvailable(filter: any, repository: Repository<any>): boolean {
+  const availableFilters = repository.metadata.columns.map((column) => column.propertyName);
+
+  if (Object.keys(filter).some((key) => availableFilters.includes(key))) {
+    return true;
+  }
+  throw new AppError("Invalid query string");
+}
+
+export function makePaginationResult(data: any, total: number, limit?: string, page?: string): PaginationResult {
+  return {
+    meta: {
+      page: Number(page) || 1,
+      limit: Number(limit),
+      total,
+      totalPages: limit ? Math.ceil(total / Math.max(Number(limit), 1)) : null,
+    },
+    data,
+  };
+}
+
+export function normalizePage(page: number) {
+  return Math.max(page - 1, 0);
+}


### PR DESCRIPTION
Add standard datagrid.
Example query string: page=1&limit=100&sort[XYZ]=ASC&filter[XYZ][]
Example response:
`{ "meta": { "page": 1, "total": 2, "limit": 1, "totalPages": 1 }, "data": [ { "id": "c8cf550b-9d3d-428d-ba1d-d26433d64956", "firstName": "John", "lastName": "Doe", "email": "john@doe.com" } ] }`