### PR TITLE
feat: modify errors response according to standard

### DIFF
--- a/shared/errors/app.error.ts
+++ b/shared/errors/app.error.ts
@@ -1,5 +1,5 @@
 export class AppError extends Error {
-  public constructor(message: string) {
+  public constructor(message?: string) {
     super(message);
 
     Object.setPrototypeOf(this, AppError.prototype);

--- a/shared/errors/not-found.error.ts
+++ b/shared/errors/not-found.error.ts
@@ -1,8 +1,9 @@
+import { StatusCodes } from "http-status-codes";
 import { HttpError } from "./http.error";
 
 export class NotFoundError extends HttpError {
-  public constructor(message: string) {
-    super(message, 404);
+  public constructor(message?: string) {
+    super(StatusCodes.NOT_FOUND, message);
 
     Object.setPrototypeOf(this, NotFoundError.prototype);
   }

--- a/shared/middleware/zod-validator.ts
+++ b/shared/middleware/zod-validator.ts
@@ -11,8 +11,15 @@ export const zodValidator = <T extends ZodTypeAny>(schema: T): Required<Pick<Mid
     const parserResult = schema.safeParse(event);
 
     if (!parserResult.success) {
+      const validationErrors: { [key: string]: string[] } = {};
+      parserResult.error.issues.forEach((issue) => {
+        const key = issue.path.join(".");
+        const errorType = `validation.${issue.code}`;
+        validationErrors[key] = validationErrors[key] || [];
+        validationErrors[key].push(errorType);
+      });
       // @ts-ignore
-      throw new HttpError(parserResult.error.issues, StatusCodes.BAD_REQUEST);
+      throw new HttpError(StatusCodes.BAD_REQUEST, validationErrors);
     }
 
     event.body = parserResult.data?.body ?? event.body;


### PR DESCRIPTION
Modify error response according to template:
```
"validation errors"
{
  errors: {
    "name": [
      "key1",
    ],
    "name.[0]": [
      "kay2",
    ]
  }
}

//"throw new Error"
{
  error: {
    code: "error.code",
    message?: "Message",
  }
}
```